### PR TITLE
runtime keyword

### DIFF
--- a/Entry.pb
+++ b/Entry.pb
@@ -508,8 +508,8 @@ If Program\SourceFileHandle And Program\HeaderFileHandle
       CodeLines$(CodeLinesCount) = Trim(CodeChunks$(i)) ; Trim whitespace from beginning / end of line.
       
       ; Remove "Runtime" keyword as it's not important.
-      If LCase(Left(CodeChunks$(i), 8)) = "runtime "
-        CodeLines$(CodeLinesCount) = Trim(Mid(CodeChunks$(i), 8)) ; Trim whitespace from beginning / end of line.
+      If LCase(Left(CodeLines$(CodeLinesCount), 8)) = "runtime "
+        CodeLines$(CodeLinesCount) = Trim(Mid(CodeLines$(CodeLinesCount), 8)) ; Trim whitespace from beginning / end of line.
       EndIf
       
       ; Handle comments after a colon was detected.
@@ -536,9 +536,8 @@ If Program\SourceFileHandle And Program\HeaderFileHandle
 Else
   End ; Unable to access the files required.
 EndIf
-; IDE Options = PureBasic 5.71 LTS (Windows - x86)
-; CursorPosition = 192
-; FirstLine = 170
+; IDE Options = PureBasic 5.72 (Windows - x64)
+; CursorPosition = 8
 ; Folding = ---
 ; EnableXP
 ; UseIcon = ..\_Resources [R]\Icons\headers.ico

--- a/Entry.pbi
+++ b/Entry.pbi
@@ -1,5 +1,5 @@
 ;- PBHGEN V5.71 [http://00laboratories.com/]
-;- 'Entry.pb' header, generated at 16:53:30 29.09.2019.
+;- 'Entry.pb' header, generated at 15:20:51 13.05.2020.
 
 CompilerIf #PB_Compiler_Module = ""
 Declare ExplodeStringArray(Array a$(1), s$, delimeter$)

--- a/PBHGEN.pbp
+++ b/PBHGEN.pbp
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.71 LTS (Windows - x86)">
+<project xmlns="http://www.purebasic.com/namespace" version="1.0" creator="PureBasic 5.72 (Windows - x64)">
   <section name="config">
     <options closefiles="1" openmode="0" name="PBHGEN"/>
   </section>
   <section name="data">
     <explorer view="" pattern="0"/>
     <log show="1"/>
-    <lastopen date="2019-09-29 17:06" user="Henry00" host="HENRY00-PC"/>
+    <lastopen date="2020-05-13 15:21" user="eric" host="BRADBURY"/>
   </section>
   <section name="files">
     <file name="Entry.pb">
       <config load="0" scan="1" panel="1" warn="1" lastopen="1" panelstate="+"/>
-      <fingerprint md5="5d2b2bcc5457775d9c9ddecc5362165f"/>
+      <fingerprint md5="7c7c4f4ed7ddcd380bbb50b6cbc633ff"/>
     </file>
   </section>
   <section name="targets">

--- a/Test.pb
+++ b/Test.pb
@@ -92,7 +92,7 @@ Module TestA
     TestA::Func1()
   EndProcedure
   
-  Procedure A() : PeekS(*lol) : EndProcedure : ;Procedure B() : PeekA(*pff) : EndProcedure
+  Runtime Procedure A() : PeekS(*lol) : EndProcedure : ;Procedure B() : PeekA(*pff) : EndProcedure
 EndModule;COMMENT
 
 DeclareModule TestB
@@ -106,7 +106,7 @@ EndDeclareModule
 Module TestB
   IncludeFile #PB_Compiler_File + "i" ;- PBHGEN
   
-  Procedure FuncHurrDurr(Cheese$ = "I love::sandwhiche~")
+  Runtime Procedure FuncHurrDurr(Cheese$ = "I love::sandwhiche~")
     
   EndProcedure
 EndModule
@@ -114,8 +114,9 @@ EndModule
 Procedure OnVstMain(*Effect.TestB::AEffect)
   Debug "Cheese": :;::Debug "LOL"
 EndProcedure
-; IDE Options = PureBasic 5.71 LTS (Windows - x86)
-; CursorPosition = 101
-; FirstLine = 74
+; IDE Options = PureBasic 5.72 (Windows - x64)
+; CursorPosition = 77
+; FirstLine = 66
 ; Folding = -----
 ; EnableXP
+; Executable = build\PBHGEN.exe

--- a/Test.pbi
+++ b/Test.pbi
@@ -1,5 +1,5 @@
 ;- PBHGEN V5.71 [http://00laboratories.com/]
-;- 'Test.pb' header, generated at 16:54:06 29.09.2019.
+;- 'Test.pb' header, generated at 15:19:41 13.05.2020.
 
 CompilerIf #PB_Compiler_Module = ""
 Declare NormalEmptyProcedure()


### PR DESCRIPTION
Hello, I noticed the runtime keyword did not work. After debugging I noticed the line wasn't being trimmed properly. I corrected the error and now runtime is properly removed from the line to be later processed. I also added the runtime keyword to a few of the procedures in the test file.